### PR TITLE
husky 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ out/
 
 .DS_Store
 .env
+
+/node_modules

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# 현재 브랜치 이름 가져오기
+BRANCH_NAME=$(git branch --show-current)
+COMMIT_MSG_FILE=$1
+
+# master 및 develop 브랜치에서는 작업을 스킵
+if [ "$BRANCH_NAME" = "main" ] || [ "$BRANCH_NAME" = "dev" ]; then
+  exit 0
+fi
+
+
+echo "현재 브랜치: $BRANCH_NAME"
+
+# 브랜치명에서 ISSUE_NUMBER 추출 (형식: 커밋유형/이슈번호-이슈요약)
+if [[ $BRANCH_NAME =~ ^[a-z]+\/([0-9]+)-.+$ ]]; then
+  ISSUE_NUMBER="${BASH_REMATCH[1]}"
+else
+  echo "커밋유형/이슈번호-이슈요약 형식의 브랜치명을 사용해주세요."
+  exit 1
+fi
+
+echo "현재 브랜치: $BRANCH_NAME"
+echo "추출된 이슈 번호: $ISSUE_NUMBER"
+
+# 커밋 메시지에 이슈 번호가 없는 경우에만 추가
+if ! grep -q "(#$ISSUE_NUMBER)" "$COMMIT_MSG_FILE"; then
+    echo " (#$ISSUE_NUMBER)" >> "$COMMIT_MSG_FILE"
+fi

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -9,9 +9,6 @@ if [ "$BRANCH_NAME" = "main" ] || [ "$BRANCH_NAME" = "dev" ]; then
   exit 0
 fi
 
-
-echo "현재 브랜치: $BRANCH_NAME"
-
 # 브랜치명에서 ISSUE_NUMBER 추출 (형식: 커밋유형/이슈번호-이슈요약)
 if [[ $BRANCH_NAME =~ ^[a-z]+\/([0-9]+)-.+$ ]]; then
   ISSUE_NUMBER="${BASH_REMATCH[1]}"

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -20,7 +20,11 @@ fi
 echo "현재 브랜치: $BRANCH_NAME"
 echo "추출된 이슈 번호: $ISSUE_NUMBER"
 
-# 커밋 메시지에 이슈 번호가 없는 경우에만 추가
-if ! grep -q "(#$ISSUE_NUMBER)" "$COMMIT_MSG_FILE"; then
-    echo " (#$ISSUE_NUMBER)" >> "$COMMIT_MSG_FILE"
+# 커밋 메시지 제목에 이슈 번호를 추가
+TITLE=$(head -n 1 "$COMMIT_MSG_FILE")
+echo "현재 제목: $TITLE"
+
+# 제목에 이슈 번호가 포함되지 않으면 추가합니다.
+if ! echo "$TITLE" | grep -q "(#$ISSUE_NUMBER)"; then
+  sed -i "" "1s/$/ (#$ISSUE_NUMBER)/" "$COMMIT_MSG_FILE"  # 제목에 이슈 번호 추가
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "breaditnow",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "husky": "^9.1.7"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "devDependencies": {
+    "husky": "^8.0.0"
+  },
+  "scripts": {
+    "prepare": "husky install",
+    "postinstall": "chmod +x .husky/"
+  }
+}


### PR DESCRIPTION
## 🔥 다음 이슈를 해결했어요.
- husky를 이용하여 커밋 제목에 이슈 번호를 자동 추가 추가한다.

### 1. husky 설치(.git 폴더가 존재하는 레포지토리 최상단에서 설치)
```bash
$ npm install --save-dev husky
$ npx husky-init
```
    
### 2. .husky 폴더에 `prepare-commit-msg` 파일 생성 후, 팀 컨벤션에 맞추어 편집
    
[prepare-commit-msg](https://github.com/user-attachments/files/18754935/prepare-commit-msg.txt)

    
### 3. 폴더 권한 설정
    
```bash
$ chmod +x .husky/*
```
    
### 결과
![커밋 결과](https://github.com/user-attachments/assets/98dc99eb-3659-461a-9aa5-9b7d52900fb3)

  
<br/>

## 💬 리뷰 요청드려요.
  
<br/>

## 💭 필요한 후속작업이 있어요.
  
<br/>

<strong>
Closes: #4 
</strong>
