### PR TITLE
Spring Cloud Gateway 설정 및 경로 기준으로 라우팅 추가

### DIFF
--- a/breaditnow-auth-api/build.gradle
+++ b/breaditnow-auth-api/build.gradle
@@ -2,7 +2,9 @@ dependencies {
     implementation project(":breaditnow-redis")
     implementation project(":breaditnow-domain")
     implementation project(":breaditnow-common")
-    
+
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/breaditnow-auth-api/src/main/java/com/breaditnow/auth/AuthCheckController.java
+++ b/breaditnow-auth-api/src/main/java/com/breaditnow/auth/AuthCheckController.java
@@ -1,0 +1,19 @@
+package com.breaditnow.auth;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/")
+public class AuthCheckController {
+
+	@Value("${server.port}")
+	private String port;
+
+	@GetMapping("/check")
+	public String check() {
+		return String.format("Auth API on PORT %s", port);
+	}
+}

--- a/breaditnow-auth-api/src/main/java/com/breaditnow/auth/domain/AuthServiceController.java
+++ b/breaditnow-auth-api/src/main/java/com/breaditnow/auth/domain/AuthServiceController.java
@@ -1,0 +1,19 @@
+package com.breaditnow.auth.domain;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/")
+public class AuthServiceController {
+
+	@Value("${server.port}")
+	private String port;
+
+	@GetMapping("/check")
+	public String check() {
+		return String.format("Auth Service on PORT %s", port);
+	}
+}

--- a/breaditnow-auth-api/src/main/java/com/breaditnow/auth/global/config/SecurityConfig.java
+++ b/breaditnow-auth-api/src/main/java/com/breaditnow/auth/global/config/SecurityConfig.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-	private static final String[] AUTH = {"/oauth2/**", "/oauth/callback/**"};
+	private static final String[] AUTH = {"/oauth2/authorization/**", "/oauth/callback/**"};
 
 	private final CustomOAuth2UserService oauth2UserService;
 	private final CookieOAuth2AuthorizationRequestRepository
@@ -56,7 +56,7 @@ public class SecurityConfig {
 
 		http.authorizeHttpRequests(authorize -> authorize
 			.requestMatchers(AUTH).permitAll()
-			.anyRequest().authenticated()
+			.anyRequest().permitAll()
 		);
 
 		return http.build();

--- a/breaditnow-auth-api/src/main/resources/application.yml
+++ b/breaditnow-auth-api/src/main/resources/application.yml
@@ -2,6 +2,9 @@ server:
   port: 9000
 
 spring:
+  application:
+    name: auth-api
+
   profiles:
     active: local
 

--- a/breaditnow-common/build.gradle
+++ b/breaditnow-common/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation "org.apache.commons:commons-lang3:3.12.0"
 }
 

--- a/breaditnow-customer-api/build.gradle
+++ b/breaditnow-customer-api/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
     implementation project(":breaditnow-domain")
     implementation project(":breaditnow-common")
+
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 }
 
 test {

--- a/breaditnow-customer-api/src/main/java/com/breaditnow/customer/CustomerCheckController.java
+++ b/breaditnow-customer-api/src/main/java/com/breaditnow/customer/CustomerCheckController.java
@@ -1,0 +1,19 @@
+package com.breaditnow.customer;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/")
+public class CustomerCheckController {
+
+	@Value("${server.port}")
+	private String port;
+
+	@GetMapping("/check")
+	public String check() {
+		return String.format("Customer API on PORT %s", port);
+	}
+}

--- a/breaditnow-customer-api/src/main/resources/application.yml
+++ b/breaditnow-customer-api/src/main/resources/application.yml
@@ -2,5 +2,8 @@ server:
   port: 9001
 
 spring:
+  application:
+    name: customer-api
+
   profiles:
     active: local

--- a/breaditnow-gateway/build.gradle
+++ b/breaditnow-gateway/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
-
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-gateway', version: '4.2.0'
 }
 
 test {

--- a/breaditnow-gateway/src/main/java/com/breaditnow/gateway/config/RouteConfig.java
+++ b/breaditnow-gateway/src/main/java/com/breaditnow/gateway/config/RouteConfig.java
@@ -1,0 +1,22 @@
+package com.breaditnow.gateway.config;
+
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RouteConfig {
+	@Bean
+	public RouteLocator routeLocator(RouteLocatorBuilder builder) {
+		return builder.routes().route("auth_api", r -> r
+				.path("/auth-api/**")
+				.or()
+				.path("/oauth2/authorization/**")
+				.or()
+				.path("/oauth/callback/**")
+				.filters(f -> f.rewritePath("/auth-api/(?<segment>.*)", "/${segment}"))
+				.uri("http://localhost:9000"))
+			.build();
+	}
+}

--- a/breaditnow-gateway/src/main/java/com/breaditnow/gateway/config/RouteConfig.java
+++ b/breaditnow-gateway/src/main/java/com/breaditnow/gateway/config/RouteConfig.java
@@ -9,7 +9,8 @@ import org.springframework.stereotype.Component;
 public class RouteConfig {
 	@Bean
 	public RouteLocator routeLocator(RouteLocatorBuilder builder) {
-		return builder.routes().route("auth_api", r -> r
+		return builder.routes()
+			.route("auth_api", r -> r
 				.path("/auth-api/**")
 				.or()
 				.path("/oauth2/authorization/**")
@@ -17,6 +18,14 @@ public class RouteConfig {
 				.path("/oauth/callback/**")
 				.filters(f -> f.rewritePath("/auth-api/(?<segment>.*)", "/${segment}"))
 				.uri("http://localhost:9000"))
+			.route("customer_api", r -> r
+				.path("/customer-api/**")
+				.filters(f -> f.rewritePath("/customer-api/(?<segment>.*)", "/${segment}"))
+				.uri("http://localhost:9001"))
+			.route("owner_api", r -> r
+				.path("/owner-api/**")
+				.filters(f -> f.rewritePath("/owner-api/(?<segment>.*)", "/${segment}"))
+				.uri("http://localhost:9002"))
 			.build();
 	}
 }

--- a/breaditnow-gateway/src/main/resources/application-local.yml
+++ b/breaditnow-gateway/src/main/resources/application-local.yml
@@ -1,4 +1,0 @@
-spring:
-  config:
-    activate:
-      on-profile: local

--- a/breaditnow-gateway/src/main/resources/application-prod.yml
+++ b/breaditnow-gateway/src/main/resources/application-prod.yml
@@ -1,4 +1,0 @@
-spring:
-  config:
-    activate:
-      on-profile: prod

--- a/breaditnow-gateway/src/main/resources/application.yml
+++ b/breaditnow-gateway/src/main/resources/application.yml
@@ -8,12 +8,3 @@ spring:
   webflux:
     static-path-pattern: "/static/**"
 
-  cloud:
-    gateway:
-      routes:
-        - id: auth-api
-          uri: http://localhost:9000/
-          predicates:
-            - Path=/auth-api/**  # 소셜 로그인 콜백 요청 처리
-          filters:
-            - RewritePath=/auth-api/(?<segment>.*), /$\{segment}

--- a/breaditnow-gateway/src/main/resources/application.yml
+++ b/breaditnow-gateway/src/main/resources/application.yml
@@ -2,5 +2,18 @@ server:
   port: 8080
 
 spring:
-  profiles:
-    active: local
+  application:
+    name: gateway-service
+
+  webflux:
+    static-path-pattern: "/static/**"
+
+  cloud:
+    gateway:
+      routes:
+        - id: auth-api
+          uri: http://localhost:9000/
+          predicates:
+            - Path=/auth-api/**  # 소셜 로그인 콜백 요청 처리
+          filters:
+            - RewritePath=/auth-api/(?<segment>.*), /$\{segment}

--- a/breaditnow-owner-api/build.gradle
+++ b/breaditnow-owner-api/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
     implementation project(':breaditnow-domain')
     implementation project(":breaditnow-common")
+
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 }
 
 test {

--- a/breaditnow-owner-api/src/main/java/com/breaditnow/owner/OwnerCheckController.java
+++ b/breaditnow-owner-api/src/main/java/com/breaditnow/owner/OwnerCheckController.java
@@ -1,4 +1,4 @@
-package com.breaditnow.auth.domain;
+package com.breaditnow.owner;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,13 +7,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/")
-public class AuthServiceController {
+public class OwnerCheckController {
 
 	@Value("${server.port}")
 	private String port;
 
 	@GetMapping("/check")
 	public String check() {
-		return String.format("Auth Service on PORT %s", port);
+		return String.format("Owner API on PORT %s", port);
 	}
 }

--- a/breaditnow-owner-api/src/main/resources/application.yml
+++ b/breaditnow-owner-api/src/main/resources/application.yml
@@ -2,5 +2,8 @@ server:
   port: 9002
 
 spring:
+  application:
+    name: owner-api
+
   profiles:
     active: local

--- a/breaditnow-redis/build.gradle
+++ b/breaditnow-redis/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,7 @@ subprojects {
 
     dependencies {
         implementation 'org.springframework.boot:spring-boot-starter'
-        implementation 'org.springframework.boot:spring-boot-starter-web'
-
+        
         developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
         testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
## 🔥 다음 이슈를 해결했어요.
- Spring Cloud Gateway 설정
- Auth, Customer, Owner 경로 기준으로 라우팅
    ```java
    @Component
    public class RouteConfig {
	    @Bean
	    public RouteLocator routeLocator(RouteLocatorBuilder builder) {
		    return builder.routes()
			    .route("auth_api", r -> r
				    .path("/auth-api/**")
				    .or()
				    .path("/oauth2/authorization/**")
				    .or()
				    .path("/oauth/callback/**")
				    .filters(f -> f.rewritePath("/auth-api/(?<segment>.*)", "/${segment}"))
				    .uri("http://localhost:9000"))
			    .route("customer_api", r -> r
				    .path("/customer-api/**")
				    .filters(f -> f.rewritePath("/customer-api/(?<segment>.*)", "/${segment}"))
				    .uri("http://localhost:9001"))
			    .route("owner_api", r -> r
				    .path("/owner-api/**")
				    .filters(f -> f.rewritePath("/owner-api/(?<segment>.*)", "/${segment}"))
				    .uri("http://localhost:9002"))
			    .build();
	    }
    }
    ```
    - `/auth-api/api/check` 요청이 오면 → auth-api 모듈의 `/api/check`로 라우팅
    - `/customer-api/api/check`  → customer-api 모듈의 `/api/check`로 라우팅
    - `/owner-api/api/check`  → owner-api 모듈의 `/api/check`로 라우팅
- 예시
    - `http://localhost:8080/owner-api/api/v1/bakery` 로 요청을 보내면 → `http://localhost:9002/api/v1/bakery` 로 라우팅됨
  
<br/>

## 💬 리뷰 요청드려요.
- [ ] spring gateway랑 `spring-boot-starter-web` 의존성이랑 충돌이 납니다. 그래서 해당 의존성이 필요한 곳에 의존성 각각 추가해뒀습니다.
  
<br/>

## 💭 필요한 후속작업이 있어요.
- gateway 모듈에서 JWT 검증 필터 구현 및 설정
- gateway 모듈에서 JWT 관련 에러 핸들링
  
<br/>

<strong>
#19 
</strong>
